### PR TITLE
Develop misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Our code creates the models using configuration files. Their front ends are init
 | **Fairseq MMS**         | Pretrained models from [here](https://github.com/facebookresearch/fairseq/tree/main/examples/mms#pretrained-models)                                                                      |
 | **Fairseq XLS-R**       | Model link from [here](https://github.com/facebookresearch/fairseq/blob/main/examples/wav2vec/xlsr/README.md#xls-r)                                                          |
 | **Fairseq Wav2Vec 2.0** | Base (no finetuning) and Large (LV-60 + CV + SWBD + FSH), no finetuning, from [here](https://github.com/facebookresearch/fairseq/tree/main/examples/wav2vec#pre-trained-models)                |
-| **Fairseq HuBERT**      | Extra Large (\~1B params), trained on Libri-Light 60k hrs, no finetuning, from [here](https://github.com/facebookresearch/fairseq/tree/main/examples/wav2vec#pre-trained-models) |
+| **Fairseq HuBERT**      | Extra Large (\~1B params), trained on Libri-Light 60k hrs, no finetuning, from [here](https://github.com/facebookresearch/fairseq/tree/main/examples/hubert#pre-trained-and-fine-tuned-asr-models) |
 
 
 ### 3. Training

--- a/dataio/dataio.py
+++ b/dataio/dataio.py
@@ -29,10 +29,6 @@ def dataio_prepare(hparams):
         csv_path=hparams["valid_csv"],
         replacements={"ROOT": data_folder},
     )
-    test_data = sb.dataio.dataset.DynamicItemDataset.from_csv(
-        csv_path=hparams["test_csv"],
-        replacements={"ROOT": data_folder},
-    )
 
     # === Dataloader behaviour for TRAIN and VALID data ===
     # Step[1]: Define which column should be readed from the .csv protocol

--- a/protocols/ASVspoof2021-DF.py
+++ b/protocols/ASVspoof2021-DF.py
@@ -67,7 +67,7 @@ def collect_audio_metadata(metadata):
         file_path = os.path.join(data_folder, "flac", f"{row['ID']}.flac")
         file_id = ID_PREFIX + row["ID"]
         # All 2021-DF data is eval
-        subset_id = 'eval'
+        subset_id = 'test'
         label = row["Label"]
         # Check if file exists
         if os.path.exists(file_path):

--- a/protocols/ASVspoof2021-LA.py
+++ b/protocols/ASVspoof2021-LA.py
@@ -71,7 +71,7 @@ def collect_audio_metadata(metadata):
         file_path = os.path.join(data_folder, "flac", f"{row['ID']}.flac")
         file_id = ID_PREFIX + row["ID"]
         # All 2021-LA data is eval
-        subset_id = 'eval'
+        subset_id = 'test'
         # Check if file exists
         if os.path.exists(file_path):
             # use torchaudio.info to increase the speed of loading

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,7 @@ def load_weights(trg_state, path, func_name_change=lambda x: x):
         path, 
         map_location=lambda storage, loc: storage,
         # set to False for loading fariseq pt models: w2v_small, w2v_large, hubert_xl
-        weights_only=False,
+        weights_only=True,
     )
 
     # if it is a fairseq-style checkpoint


### PR DESCRIPTION
4 changes:

1. **Fix HuBERT link in README**.  Updated the link to Fairseq HuBERT in the README.  The previous link redirected to Wav2Vec.

2. **Update `utils.load_weights()`**.  
   - Changed `torch.load(weights_only=False)` to `torch.load(weights_only=True)`.  
   - Setting `weights_only=False` is only required for loading a few specific pre-trained Fairseq models (`w2v_small`, `w2v_large`, `hubert_xl`).  
   - In most cases (e.g., all AntiDeepfake models and pre-trained MMS XLS-R models), `weights_only=True` is sufficient.

3. **Update protocol files for ASVspoof2021-DF/LA**  
   - Replaced `Proportion == "eval"` with `Proportion == "test"` in the ASVspoof2021-DF/LA protocols.  
   - To be consistent with other protocols.

4. **Remove test_data from dataio_prepare()**
   - `test_data` is not needed when preparing datasets for training and validation.
