### PR TITLE
update-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ conda install pip==24.0
 pip install torch==2.6.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118
 
 ### Install Fariseq ###
-# fairseq 0.10.2 on pip does not work
+# pip install fairseq
+# or to reproduce our venv:
 git clone https://github.com/pytorch/fairseq
 cd fairseq
 # checkout this specific commit. Latest commit does not work
@@ -88,6 +89,8 @@ pip install --editable .
 cd ../
 
 ### Install SpeechBrain ###
+# pip install speechbrain
+# or to reproduce our venv:
 git clone https://github.com/speechbrain/speechbrain.git
 cd speechbrain
 pip install -r requirements.txt
@@ -95,11 +98,15 @@ pip install --editable .
 
 ### Install other packages ###
 pip install tensorboard tensorboardX soundfile pandarallel scikit-learn numpy==1.21.2 pandas==1.4.3 scipy==1.7.2
+
+### Clone Our Repository ###
+# Please ensure that your AntiDeepfake/working directory 
+# does not contain copies of fairseq or speechbrain repo.
 ```
 
 ## Usage demonstration
 
-Here is a demonstration of using an Antifake checkpoint for deepfake detection.
+Here is a demonstration of using an AntiDeepfake checkpoint for deepfake detection.
 
 ```bash
 # go to an empty project folder 


### PR DESCRIPTION
Two modifications:

1. Update installation guideline with an easier way of installing fairseq and speechbrain with pip.  The original way is still kept and set to default for reproduce of our experiment virtual environment.

Add a note about directory management to the README, asking users not to run the installation steps directly inside their working directory.  Doing so can lead to [this issue](https://github.com/nii-yamagishilab/AntiDeepfake/issues/4) with importing `fairseq` or `speechbrain`.  

We’ve met this problem before, but I forgot to write it explicitly in the README.  I thought the [directory structure section](https://github.com/nii-yamagishilab/AntiDeepfake?tab=readme-ov-file#0-working-directory-structure) would imply this requirement. It should be stated clearly to prevent confusion.

2. Correct a typo.