### PR TITLE
fix typo;fix speechbrain version

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@
 
 [Sep. 20, 2025] Add functions and a demo notebook for drift detection. Please check details [README_drift.md](./README_drift.md).
 
+[July 4, 2025] We added supplementary information to our training data to help guide your selection of which data to use. Please check [here](./protocols/README.md).
+
 [June 27, 2025] Initial release!!!
 
-[July 4, 2025] We added supplementary information to our training data to help guide your selection of which data to use. Please check [here](./protocols/README.md).
 
 ## Introduction
 
@@ -91,13 +92,7 @@ pip install --editable .
 cd ../
 
 ### Install SpeechBrain ###
-# pip install speechbrain
-# or to reproduce our venv:
-git clone https://github.com/speechbrain/speechbrain.git
-cd speechbrain
-pip install -r requirements.txt
-pip install --editable .
-cd ../
+pip install speechbrain==1.0.2
 
 ### Install other packages ###
 pip install tensorboard tensorboardX soundfile pandarallel scikit-learn numpy==1.21.2 pandas==1.4.3 scipy==1.7.2

--- a/install.sh
+++ b/install.sh
@@ -21,10 +21,7 @@ pip install --editable .
 cd ../
 
 ### Install SpeechBrain ###
-git clone https://github.com/speechbrain/speechbrain.git
-cd speechbrain
-pip install -r requirements.txt
-pip install --editable .
+pip install speechbrain==1.0.2
 
 ### Install other packages ###
 pip install tensorboard tensorboardX soundfile pandarallel scikit-learn numpy==1.21.2 pandas==1.4.3 scipy==1.7.2

--- a/main.py
+++ b/main.py
@@ -32,8 +32,8 @@ logger = get_logger(__name__)
 class SSLBrain(sb.core.Brain):
     def __init__(self, *args, **kargs):
         super(SSLBrain, self).__init__(*args, **kargs)
-        # in case model is defined via yaml file
-        # if case the model is not defined in yaml, add them here
+        # load model weights if it is defined via yaml file
+        # if the model weight is not defined in yaml, add them here
         # to the checkpointer recoverable settings
         # self.checkpointer.add_recoverables({})
         #
@@ -68,7 +68,7 @@ class SSLBrain(sb.core.Brain):
                 if hasattr(module_ist, 'name_map'):
                     name_mapper = module_ist.name_map
                 else:
-                    name_mapper = lambda x: f"m_ssl.model.{n}"
+                    name_mapper = lambda x: f"m_ssl.model.{x}"
                     
                 ## used for loading fairseq-style checkpoints
                 #def name_mapper(n): return f"m_ssl.model.{n}"


### PR DESCRIPTION
Two modifications:

(1) SpeechBrain version. Change both `README` and `install.sh` from installing the newest SpeechBrain to version `1.0.2`, which is the one we used during development. 

I've tested that `pip install speechbrain==1.0.2/1.0.3` both works, but installing from its cloned repo with `pip install --editable .` will get an error:
```
  File "/base_path/AntiDeepfake/main.py", line 518, in main

    run_opts["find_unused_parameters"] = True

TypeError: 'RunOptions' object does not support item assignment
```
Trying to fix it will cause more errors, so I use the simplest solution by installing an old version. This error is caused by recent changes in SpeechBrain [(here)](https://github.com/speechbrain/speechbrain/pull/2855), where RunOpts is changed to an object, not anymore a dict.

Comments:
1. Will try to modify `main.py` to work with the newest version.
2. Actually setting `run_opts["find_unused_parameters"] = True` is redundant now. Current code works smoothly without it. I originally added it because training used to break without this setting.

(2) Fixing some typos, one will cause error when loading pretrained weights:
```
# Line 71 in main.py, here should be {x} rather than {n}
name_mapper = lambda x: f"m_ssl.model.{n}"
```

Comment:
1. I found that the related `_init_model()` does not work with checkpoints downloaded in .safetensors format. Will solve latter.